### PR TITLE
add ability to assume role using config param `role_arn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
+## [1.2.1](https://github.com/ome9ax/target-s3-jsonl/tree/1.2.1) (2022-07-13)
 
+### What's Changed
+* Added optional config parameter `role_arn`, which allows assuming additional roles.
 ## [1.2.0](https://github.com/ome9ax/target-s3-jsonl/tree/1.2.0) (2022-04-11)
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Full list of options in `config.json`:
 | aws_session_token                   | String  |            | AWS Session token. If not provided, `AWS_SESSION_TOKEN` environment variable will be used. |
 | encryption_type                     | String  |            | (Default: 'none') The type of encryption to use. Current supported options are: 'none' and 'KMS'. |
 | encryption_key                      | String  |            | A reference to the encryption key to use for data encryption. For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234'). This field is ignored if 'encryption_type' is none or blank. |
+| role_arn                            | String  |            | The ARN of the role to assume |
 
 ## Test
 Install the tools

--- a/config.sample.json
+++ b/config.sample.json
@@ -4,5 +4,6 @@
     "s3_bucket": "BUCKET",
     "s3_key_prefix": "SOME-PREFIX/",
     "compression": "gzip",
-    "naming_convention": "{stream}-{timestamp}.jsonl"
+    "naming_convention": "{stream}-{timestamp}.jsonl",
+    "role_arn": "arn:aws:iam::000000000000:role/my_custom_role"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ target_s3_jsonl = logging.conf
 [options.extras_require]
 test =
     pytest-cov
-    moto[s3]
+    moto[s3,sts]
 lint = flake8
 dist = wheel
 

--- a/target_s3_jsonl/__init__.py
+++ b/target_s3_jsonl/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 import argparse
 import gzip

--- a/target_s3_jsonl/__init__.py
+++ b/target_s3_jsonl/__init__.py
@@ -238,6 +238,7 @@ def config_file(config_path):
         'aws_session_token',
         'aws_endpoint_url',
         'aws_profile',
+        'role_arn',
         's3_bucket',
         's3_key_prefix',
         'encryption_type',

--- a/target_s3_jsonl/s3.py
+++ b/target_s3_jsonl/s3.py
@@ -53,7 +53,7 @@ def create_client(config):
     if role_arn:
         role_name = role_arn.split('/', 1)[1]
         sts = aws_session.client('sts', **endpoint_params)
-        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-role={role_name}-profile={aws_profile}')
+        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'role-name={role_name}-profile={aws_profile}')
         credentials = {
             "aws_access_key_id": resp["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": resp["Credentials"]["SecretAccessKey"],

--- a/target_s3_jsonl/s3.py
+++ b/target_s3_jsonl/s3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import re
 import time
 import backoff
 import boto3
@@ -52,7 +53,7 @@ def create_client(config):
     if role_arn:
         role_name = role_arn.split('/', 1)[1]
         sts = aws_session.client('sts', **endpoint_params)
-        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-role:{role_name}-profile:{aws_profile}')
+        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-role={role_name}-profile={aws_profile}')
         credentials = {
             "aws_access_key_id": resp["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": resp["Credentials"]["SecretAccessKey"],

--- a/target_s3_jsonl/s3.py
+++ b/target_s3_jsonl/s3.py
@@ -34,9 +34,9 @@ def create_client(config):
     aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
     aws_endpoint_url = config.get('aws_endpoint_url')
     role_arn = config.get('role_arn')
-    
+
     endpoint_parmas = {'endpoint_url': aws_endpoint_url} if aws_endpoint_url else {}
-    
+
     # AWS credentials based authentication
     if aws_access_key_id and aws_secret_access_key:
         aws_session = boto3.session.Session(
@@ -46,18 +46,22 @@ def create_client(config):
     # AWS Profile based authentication
     else:
         aws_session = boto3.session.Session(profile_name=aws_profile)
+
+    # config specifies a particular role to assume
+    # we create a session & s3-client with this role
     if role_arn:
         role_name = role_arn.split('/', 1)[1]
         sts = aws_session.client('sts', **endpoint_params)
-        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-{role_name}-profile:{aws_profile}-{int(time.time())}')
+        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-role:{role_name}-profile:{aws_profile}')
         credentials = {
             "aws_access_key_id": resp["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": resp["Credentials"]["SecretAccessKey"],
             "aws_session_token": resp["Credentials"]["SessionToken"],
         }
         aws_session = boto3.Session(**credentials)
+        LOGGER.info(f"Creating s3 client with role {role_name}")
     return aws_session.client('s3', **endpoint_params)
-    
+
 
 # pylint: disable=too-many-arguments
 @retry_pattern()

--- a/target_s3_jsonl/s3.py
+++ b/target_s3_jsonl/s3.py
@@ -35,7 +35,7 @@ def create_client(config):
     aws_endpoint_url = config.get('aws_endpoint_url')
     role_arn = config.get('role_arn')
 
-    endpoint_parmas = {'endpoint_url': aws_endpoint_url} if aws_endpoint_url else {}
+    endpoint_params = {'endpoint_url': aws_endpoint_url} if aws_endpoint_url else {}
 
     # AWS credentials based authentication
     if aws_access_key_id and aws_secret_access_key:

--- a/target_s3_jsonl/s3.py
+++ b/target_s3_jsonl/s3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import time
 import backoff
 import boto3
 from botocore.exceptions import ClientError
@@ -32,7 +33,10 @@ def create_client(config):
     aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
     aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
     aws_endpoint_url = config.get('aws_endpoint_url')
-
+    role_arn = config.get('role_arn')
+    
+    endpoint_parmas = {'endpoint_url': aws_endpoint_url} if aws_endpoint_url else {}
+    
     # AWS credentials based authentication
     if aws_access_key_id and aws_secret_access_key:
         aws_session = boto3.session.Session(
@@ -42,12 +46,18 @@ def create_client(config):
     # AWS Profile based authentication
     else:
         aws_session = boto3.session.Session(profile_name=aws_profile)
-
-    if aws_endpoint_url:
-        return aws_session.client('s3', endpoint_url=aws_endpoint_url)
-    else:
-        return aws_session.client('s3')
-
+    if role_arn:
+        role_name = role_arn.split('/', 1)[1]
+        sts = aws_session.client('sts', **endpoint_params)
+        resp = sts.assume_role(RoleArn=role_arn, RoleSessionName=f'Meltano-{role_name}-profile:{aws_profile}-{int(time.time())}')
+        credentials = {
+            "aws_access_key_id": resp["Credentials"]["AccessKeyId"],
+            "aws_secret_access_key": resp["Credentials"]["SecretAccessKey"],
+            "aws_session_token": resp["Credentials"]["SessionToken"],
+        }
+        aws_session = boto3.Session(**credentials)
+    return aws_session.client('s3', **endpoint_params)
+    
 
 # pylint: disable=too-many-arguments
 @retry_pattern()

--- a/tests/resources/config_assume_role.json
+++ b/tests/resources/config_assume_role.json
@@ -1,0 +1,13 @@
+{
+    "add_metadata_columns": false,
+    "aws_access_key_id": "ACCESS-KEY",
+    "aws_secret_access_key": "SECRET",
+    "s3_bucket": "BUCKET",
+    "temp_dir": "tests/output",
+    "memory_buffer": 2000000,
+    "compression": "none",
+    "timezone_offset": 0,
+    "naming_convention": "{stream}-{timestamp:%Y%m%dT%H%M%S}.jsonl",
+    "role_arn": "arn:aws:iam::123456789012:role/TestAssumeRole"
+
+}


### PR DESCRIPTION
# What this Does

* added a new config variable `role_arn` that expects an ARN of a role in the following format: ```arn:aws:iam::123456789012:role/role_name```
* if this is present, we'll use an sts client to assume the provided role, and then create an s3 client out of it.

# Why this is useful

Sometimes in security restricted settings, the landing role that a container is started with will not have all the necessary permissions, separate roles will have to be assumed to interact with different services (e.g. by default you can't write to s3 unless you assume the writer role) 

# Other Notes

The changes in this PR do not modify existing functionality, thus it is completely backwards compatible.
